### PR TITLE
feat: add install/uninstall scripts and ruff per-file-ignores

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Install windsurf-teacher into Windsurf Next."""
+
+from __future__ import annotations
+
+from windsurf_teacher.installer import run_install
+
+if __name__ == "__main__":
+    run_install()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,8 @@ ignore = [
     "DTZ005",     # Naive datetime in tests is fine
     "PLR0904",    # Test classes naturally have many test methods
 ]
+"install.py" = ["T201"]   # CLI script needs print()
+"uninstall.py" = ["T201"] # CLI script needs print()
 
 [tool.ruff.lint.pylint]
 # All values are pylint defaults — do not inflate to hide violations.

--- a/src/windsurf_teacher/installer.py
+++ b/src/windsurf_teacher/installer.py
@@ -1,18 +1,179 @@
-"""Install/uninstall windsurf-teacher into Windsurf Next.
-
-Full implementation added in a subsequent PR.
-"""
+"""Install/uninstall windsurf-teacher into Windsurf Next."""
 
 from __future__ import annotations
+
+import json
+import shlex
+import shutil
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent.parent
+WINDSURF_NEXT_DIR = Path.home() / ".codeium" / "windsurf-next"
+SKILL_DIR = WINDSURF_NEXT_DIR / "skills" / "learn-mode"
+HOOKS_CONFIG = WINDSURF_NEXT_DIR / "hooks.json"
+MCP_CONFIG = WINDSURF_NEXT_DIR / "mcp_config.json"
+DB_DIR = Path.home() / ".windsurf-teacher"
+
+HOOK_EVENTS = ("post_cascade_response", "post_write_code", "post_run_command")
+MCP_SERVER_NAME = "windsurf-teacher"
+
+
+def _print(msg: str) -> None:
+    print(msg)  # noqa: T201
+
+
+def _python_path() -> str:
+    """Resolve the project venv's python3 absolute path."""
+    venv_python = PROJECT_DIR / ".venv" / "bin" / "python3"
+    if not venv_python.exists():
+        msg = f"Venv python not found at {venv_python}. Run 'uv sync' first."
+        raise FileNotFoundError(msg)
+    return str(venv_python.resolve())
+
+
+def _hooks_dir() -> str:
+    """Resolve absolute path to the hooks directory."""
+    return str((PROJECT_DIR / "src" / "windsurf_teacher" / "hooks").resolve())
+
+
+def _build_hook_command() -> str:
+    return f"{shlex.quote(_python_path())} {shlex.quote(f'{_hooks_dir()}/capture_session.py')}"
+
+
+def _load_json(path: Path) -> dict:
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {}
+
+
+def _save_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def _install_skill() -> None:
+    """Copy SKILL.md into the global skills directory."""
+    source = PROJECT_DIR / "SKILL.md"
+    if not source.exists():
+        _print(f"  ⚠ SKILL.md not found at {source}")
+        return
+    SKILL_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, SKILL_DIR / "SKILL.md")
+    _print(f"  ✓ Skill installed to {SKILL_DIR}")
+
+
+def _install_hooks() -> None:
+    """Merge our hook entries into the user-level hooks.json."""
+    config = _load_json(HOOKS_CONFIG)
+    hooks = config.setdefault("hooks", {})
+    command = _build_hook_command()
+
+    hook_entry = {"command": command, "show_output": False}
+
+    for event in HOOK_EVENTS:
+        event_hooks = hooks.setdefault(event, [])
+        if not any(h.get("command") == command for h in event_hooks):
+            event_hooks.append(hook_entry)
+
+    _save_json(HOOKS_CONFIG, config)
+    _print(f"  ✓ Hooks installed to {HOOKS_CONFIG}")
+
+
+def _install_mcp_server() -> None:
+    """Register the MCP server in mcp_config.json."""
+    config = _load_json(MCP_CONFIG)
+    servers = config.setdefault("mcpServers", {})
+
+    servers[MCP_SERVER_NAME] = {
+        "command": "uv",
+        "args": ["run", "--directory", str(PROJECT_DIR), "windsurf-teacher", "serve"],
+    }
+
+    _save_json(MCP_CONFIG, config)
+    _print(f"  ✓ MCP server registered in {MCP_CONFIG}")
+
+
+def _create_db_dir() -> None:
+    """Create the learning database directory."""
+    DB_DIR.mkdir(parents=True, exist_ok=True)
+    _print(f"  ✓ Database directory: {DB_DIR}")
+
+
+def _uninstall_skill() -> None:
+    """Remove the learn-mode skill directory."""
+    if SKILL_DIR.exists():
+        shutil.rmtree(SKILL_DIR)
+        _print(f"  ✓ Removed skill: {SKILL_DIR}")
+    else:
+        _print("  - Skill not installed, skipping")
+
+
+def _uninstall_hooks() -> None:
+    """Remove our hook entries from hooks.json (leave other hooks intact)."""
+    if not HOOKS_CONFIG.exists():
+        _print("  - No hooks.json found, skipping")
+        return
+
+    config = _load_json(HOOKS_CONFIG)
+    hooks = config.get("hooks", {})
+    removed = False
+
+    for event in HOOK_EVENTS:
+        if event in hooks:
+            original_len = len(hooks[event])
+            hooks[event] = [h for h in hooks[event] if "capture_session.py" not in h.get("command", "")]
+            if len(hooks[event]) < original_len:
+                removed = True
+            if not hooks[event]:
+                del hooks[event]
+
+    if removed:
+        _save_json(HOOKS_CONFIG, config)
+        _print(f"  ✓ Hooks removed from {HOOKS_CONFIG}")
+    else:
+        _print("  - No windsurf-teacher hooks found, skipping")
+
+
+def _uninstall_mcp_server() -> None:
+    """Remove our MCP server entry from mcp_config.json."""
+    if not MCP_CONFIG.exists():
+        _print("  - No mcp_config.json found, skipping")
+        return
+
+    config = _load_json(MCP_CONFIG)
+    servers = config.get("mcpServers", {})
+
+    if MCP_SERVER_NAME in servers:
+        del servers[MCP_SERVER_NAME]
+        _save_json(MCP_CONFIG, config)
+        _print(f"  ✓ MCP server removed from {MCP_CONFIG}")
+    else:
+        _print("  - MCP server not registered, skipping")
 
 
 def run_install() -> None:
     """Install windsurf-teacher skill, hooks, and MCP server into Windsurf Next."""
-    msg = "Not yet implemented — use install.py directly."
-    raise NotImplementedError(msg)
+    _print("Installing windsurf-teacher...")
+    _install_skill()
+    _install_hooks()
+    _install_mcp_server()
+    _create_db_dir()
+    _print("\nDone! Restart Windsurf to activate.")
 
 
 def run_uninstall() -> None:
     """Uninstall windsurf-teacher from Windsurf Next."""
-    msg = "Not yet implemented — use uninstall.py directly."
-    raise NotImplementedError(msg)
+    _print("Uninstalling windsurf-teacher...")
+    _uninstall_skill()
+    _uninstall_hooks()
+    _uninstall_mcp_server()
+
+    if DB_DIR.exists():
+        answer = input(f"\nDelete learning database at {DB_DIR}? [y/N] ").strip().lower()
+        if answer == "y":
+            shutil.rmtree(DB_DIR)
+            _print(f"  ✓ Removed {DB_DIR}")
+        else:
+            _print(f"  - Kept {DB_DIR}")
+
+    _print("\nDone! Restart Windsurf to deactivate.")

--- a/uninstall.py
+++ b/uninstall.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Uninstall windsurf-teacher from Windsurf Next."""
+
+from __future__ import annotations
+
+from windsurf_teacher.installer import run_uninstall
+
+if __name__ == "__main__":
+    run_uninstall()


### PR DESCRIPTION
## Summary

Add the full install/uninstall system for windsurf-teacher, including root-level convenience scripts and ruff per-file-ignores.

## What changed

- **`src/windsurf_teacher/installer.py`** — full implementation replacing the stub: installs skill, hooks, MCP server config, and creates the DB directory; uninstall merges/removes entries cleanly
- **`install.py`** / **`uninstall.py`** — root-level convenience scripts (executable with shebang)
- **`pyproject.toml`** — added ruff per-file-ignores for `install.py` and `uninstall.py` (`T201` — they need `print()`)

## Install actions

1. Copies `SKILL.md` → `~/.codeium/windsurf-next/skills/learn-mode/`
2. Merges hook entries into `~/.codeium/windsurf-next/hooks.json` (preserves existing hooks)
3. Registers MCP server in `~/.codeium/windsurf-next/mcp_config.json`
4. Creates `~/.windsurf-teacher/` database directory

## Design decisions

- **Merge, never overwrite** — both `hooks.json` and `mcp_config.json` are merged with existing entries so other tools are not affected
- **Idempotent** — running install twice does not duplicate hook entries (checked by command string)
- **Uninstall asks about DB** — the learning database is user data; uninstall prompts `[y/N]` before deleting it
- **`_build_hook_command()`** resolves the venv python and hook script as absolute paths for reliability