### PR TITLE
feat: add learn-review global workflow

### DIFF
--- a/learn-review.md
+++ b/learn-review.md
@@ -1,0 +1,10 @@
+---
+description: Review recent learnings and quiz me
+auto_execution_mode: 1
+---
+
+1. Use the windsurf-teacher MCP tools to fetch recent concepts with `get_learning_gaps`
+2. Pick 3-5 concepts that are due for review
+3. For each concept, briefly explain it and ask me a question that tests understanding (not memory)
+4. After I answer, confirm whether I got it right and add any nuance I missed
+5. At the end, use `log_concept` to update the review_count for concepts I got right


### PR DESCRIPTION
## Summary

Add a global workflow file for spaced-repetition review of recent learnings.

## What changed

- **`learn-review.md`** — Windsurf global workflow with YAML frontmatter (`auto_execution_mode: 1`). When copied to `~/.codeium/windsurf-next/global_workflows/`, it adds a `/learn-review` slash command.

## How it works

The workflow instructs Cascade to:

1. Fetch concepts due for review via `get_learning_gaps`
2. Pick 3–5 concepts and quiz the user (testing understanding, not memory)
3. Confirm answers and fill in nuance
4. Update `review_count` for correctly answered concepts