### PR TITLE
test: add tests for mcp_server, cli, installer; coverage 91%+

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,113 @@
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 [![codecov](https://codecov.io/gh/detailobsessed/windsurf-teacher/branch/main/graph/badge.svg)](https://codecov.io/gh/detailobsessed/windsurf-teacher)
 
-Windsurf but you learn as you code
+**Learn as you vibe-engineer.** Instead of blindly accepting AI-generated code, windsurf-teacher makes Cascade explain everything it does, captures session logs via hooks, stores structured learning data in SQLite, and provides an MCP server so Cascade can actively log concepts during sessions.
 
-## Branch protection
+## How it works
 
-The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
-Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-a-branch-protection-rule/managing-a-branch-protection-rule) for `main` requiring the **`ci-pass`** status check to pass before merging.
+```text
+coding sessions → hooks capture responses/diffs → SQLite stores structured learnings
+                                                 → export to markdown → NotebookLM flashcards
+```
+
+- **Skill** (`@learn-mode`) — changes Cascade's behavior to explain before writing, annotate code with `# LEARN:` comments, and summarize patterns
+- **Hooks** — silently capture every Cascade response, code edit, and command to SQLite
+- **MCP server** — Cascade calls tools like `log_concept`, `log_pattern`, `log_gotcha` when teaching
+- **CLI** — review, export, and search your learnings outside of Windsurf
+
+## Requirements
+
+- Python 3.14+
+- [uv](https://docs.astral.sh/uv/)
+- [Windsurf Next](https://windsurf.com)
+
+## Installation
+
+```bash
+# Clone and set up
+git clone https://github.com/detailobsessed/windsurf-teacher.git
+cd windsurf-teacher
+uv sync
+
+# Install into Windsurf Next (skill, hooks, MCP server)
+uv run windsurf-teacher install
+```
+
+This installs:
+
+1. The `learn-mode` skill into `~/.codeium/windsurf-next/skills/learn-mode/`
+2. Hook entries into `~/.codeium/windsurf-next/hooks.json` (merged with existing hooks)
+3. The MCP server into `~/.codeium/windsurf-next/mcp_config.json`
+4. The learning database directory at `~/.windsurf-teacher/`
+
+Restart Windsurf after installing.
+
+## Usage
+
+### In Windsurf
+
+Activate the skill by typing `@learn-mode` in Cascade. Cascade will:
+
+- Explain what it's about to do and why before writing code
+- Add `# LEARN:` comments on non-obvious lines
+- Log concepts, patterns, and gotchas to the database via MCP tools
+- Summarize what you should know after each task
+- Ask one comprehension question
+
+### CLI
+
+```bash
+# Show learning statistics
+windsurf-teacher stats
+
+# Full-text search across concepts
+windsurf-teacher search "context manager"
+
+# Show concepts due for review (not reviewed in >3 days)
+windsurf-teacher review
+
+# Export recent learnings to markdown (for NotebookLM)
+windsurf-teacher export --days 7 --output review.md
+
+# Start the MCP server manually (usually not needed)
+windsurf-teacher serve
+```
+
+### Global workflow
+
+Copy `learn-review.md` to `~/.codeium/windsurf-next/global_workflows/` to add a `/learn-review` command that quizzes you on recent concepts.
+
+## Uninstalling
+
+```bash
+uv run windsurf-teacher uninstall
+```
+
+This removes the skill, hooks, and MCP server entries (leaving other hooks/servers intact). You'll be asked whether to delete the learning database.
+
+## Development
+
+```bash
+uv sync                  # Install all dependencies
+uv run poe check         # Lint + typecheck
+uv run poe test          # Run tests
+uv run poe test-cov      # Tests with coverage
+```
+
+## Architecture
+
+```text
+src/windsurf_teacher/
+├── db.py                 # SQLite schema (7 tables + FTS5), get_db()
+├── hooks/
+│   └── capture_session.py  # Hook handler (stdin JSON → SQLite)
+├── mcp_server.py         # FastMCP v3 server (7 tools)
+├── cli.py                # CLI (cyclopts)
+└── installer.py          # Install/uninstall logic
+
+install.py                # Root-level install script
+uninstall.py              # Root-level uninstall script
+hooks.json                # Hook template with placeholders
+SKILL.md                  # Learn-mode skill definition
+learn-review.md           # Global workflow for review quizzes
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,12 @@ output = "htmlcov/coverage.json"
 python-version = "3.14"
 python = ".venv"
 
+[[tool.ty.overrides]]
+include = ["tests/test_mcp_server.py"]
+
+[tool.ty.overrides.rules]
+call-non-callable = "ignore"  # FastMCP v3 rc2 type stubs incorrectly expose FunctionTool
+
 [tool.poe.tasks]
 # Setup
 setup = "uv sync"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,134 @@
+"""Tests for windsurf_teacher.cli module."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from windsurf_teacher.db import get_db
+
+
+@pytest.fixture
+def _patch_db(tmp_path, monkeypatch):
+    """Patch get_db in cli to use a temp database."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr("windsurf_teacher.cli.get_db", lambda: get_db(db_path))
+
+
+@pytest.fixture
+def db_conn(tmp_path, _patch_db):
+    db_path = tmp_path / "test.db"
+    conn = get_db(db_path)
+    yield conn
+    conn.close()
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestStats:
+    def test_stats_empty_db(self, capsys):
+        from windsurf_teacher.cli import stats
+
+        stats()
+        out = capsys.readouterr().out
+        assert "Sessions:  0" in out
+        assert "Concepts:  0" in out
+
+    def test_stats_with_data(self, db_conn, capsys):
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('s1', '2025-01-01')")
+        db_conn.execute(
+            "INSERT INTO concepts (session_id, timestamp, name, explanation, tags, source) "
+            "VALUES ('s1', '2025-01-01', 'test', 'test concept', 'python,testing', 'mcp')"
+        )
+        db_conn.commit()
+
+        from windsurf_teacher.cli import stats
+
+        stats()
+        out = capsys.readouterr().out
+        assert "Sessions:  1" in out
+        assert "Concepts:  1" in out
+        assert "python" in out
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestSearch:
+    def test_search_no_results(self, capsys):
+        from windsurf_teacher.cli import search
+
+        search("nonexistent")
+        out = capsys.readouterr().out
+        assert "No concepts found" in out
+
+    def test_search_finds_concept(self, db_conn, capsys):
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('s1', '2025-01-01')")
+        db_conn.execute(
+            "INSERT INTO concepts (session_id, timestamp, name, explanation, tags, source) "
+            "VALUES ('s1', '2025-01-01', 'decorator', 'wraps functions', 'python', 'hook')"
+        )
+        db_conn.commit()
+
+        from windsurf_teacher.cli import search
+
+        search("decorator")
+        out = capsys.readouterr().out
+        assert "decorator" in out
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestReview:
+    def test_review_no_concepts(self, capsys):
+        from windsurf_teacher.cli import review
+
+        review()
+        out = capsys.readouterr().out
+        assert "up to date" in out
+
+    def test_review_shows_unreviewed(self, db_conn, capsys):
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('s1', '2025-01-01')")
+        db_conn.execute(
+            "INSERT INTO concepts (session_id, timestamp, name, explanation, tags, source) "
+            "VALUES ('s1', '2025-01-01', 'pathlib', 'object paths', '', 'mcp')"
+        )
+        db_conn.commit()
+
+        from windsurf_teacher.cli import review
+
+        review()
+        out = capsys.readouterr().out
+        assert "pathlib" in out
+        assert "never reviewed" in out
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestExport:
+    def test_export_to_stdout(self, db_conn, capsys):
+        now = datetime.now(tz=UTC).isoformat()
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('s1', ?)", (now,))
+        db_conn.execute(
+            "INSERT INTO concepts (session_id, timestamp, name, explanation, tags, source) "
+            "VALUES ('s1', ?, 'test', 'test concept', '', 'mcp')",
+            (now,),
+        )
+        db_conn.commit()
+
+        from windsurf_teacher.cli import export
+
+        export(days=7)
+        out = capsys.readouterr().out
+        assert "Learning Review" in out
+
+    def test_export_to_file(self, db_conn, tmp_path):
+        from windsurf_teacher.cli import export
+
+        output_path = str(tmp_path / "export.md")
+        export(days=365, output=output_path)
+        assert (tmp_path / "export.md").exists()
+
+
+class TestMain:
+    def test_main_no_args(self):
+        from windsurf_teacher.cli import main
+
+        with pytest.raises(SystemExit):
+            main()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,228 @@
+"""Tests for windsurf_teacher.installer module."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from windsurf_teacher.installer import (
+    HOOK_EVENTS,
+    MCP_SERVER_NAME,
+    _install_hooks,
+    _install_mcp_server,
+    _install_skill,
+    _load_json,
+    _save_json,
+    _uninstall_hooks,
+    _uninstall_mcp_server,
+    _uninstall_skill,
+    run_install,
+    run_uninstall,
+)
+
+
+@pytest.fixture
+def _patch_paths(tmp_path, monkeypatch):
+    """Redirect all installer paths to tmp_path."""
+    monkeypatch.setattr("windsurf_teacher.installer.WINDSURF_NEXT_DIR", tmp_path / "windsurf-next")
+    monkeypatch.setattr("windsurf_teacher.installer.SKILL_DIR", tmp_path / "windsurf-next" / "skills" / "learn-mode")
+    monkeypatch.setattr("windsurf_teacher.installer.HOOKS_CONFIG", tmp_path / "windsurf-next" / "hooks.json")
+    monkeypatch.setattr("windsurf_teacher.installer.MCP_CONFIG", tmp_path / "windsurf-next" / "mcp_config.json")
+    monkeypatch.setattr("windsurf_teacher.installer.DB_DIR", tmp_path / "db")
+
+
+class TestJsonHelpers:
+    def test_load_json_missing_file(self, tmp_path):
+        result = _load_json(tmp_path / "missing.json")
+        assert result == {}
+
+    def test_load_json_existing_file(self, tmp_path):
+        path = tmp_path / "test.json"
+        path.write_text('{"key": "value"}', encoding="utf-8")
+        result = _load_json(path)
+        assert result == {"key": "value"}
+
+    def test_save_json_creates_parents(self, tmp_path):
+        path = tmp_path / "sub" / "dir" / "test.json"
+        _save_json(path, {"hello": "world"})
+        assert path.exists()
+        assert json.loads(path.read_text(encoding="utf-8")) == {"hello": "world"}
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestInstallSkill:
+    def test_copies_skill_md(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "SKILL.md").write_text("# test skill", encoding="utf-8")
+        monkeypatch.setattr("windsurf_teacher.installer.PROJECT_DIR", project_dir)
+
+        _install_skill()
+        skill_path = tmp_path / "windsurf-next" / "skills" / "learn-mode" / "SKILL.md"
+        assert skill_path.exists()
+        assert skill_path.read_text(encoding="utf-8") == "# test skill"
+
+    def test_warns_if_skill_missing(self, tmp_path, monkeypatch, capsys):
+        project_dir = tmp_path / "empty-project"
+        project_dir.mkdir()
+        monkeypatch.setattr("windsurf_teacher.installer.PROJECT_DIR", project_dir)
+
+        _install_skill()
+        assert "not found" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestInstallHooks:
+    def test_adds_hook_entries(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("windsurf_teacher.installer._build_hook_command", lambda: "/usr/bin/python capture.py")
+
+        _install_hooks()
+        hooks_path = tmp_path / "windsurf-next" / "hooks.json"
+        config = json.loads(hooks_path.read_text(encoding="utf-8"))
+        for event in HOOK_EVENTS:
+            assert event in config["hooks"]
+            assert any(h["command"] == "/usr/bin/python capture.py" for h in config["hooks"][event])
+
+    def test_idempotent_install(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("windsurf_teacher.installer._build_hook_command", lambda: "/usr/bin/python capture.py")
+
+        _install_hooks()
+        _install_hooks()
+        hooks_path = tmp_path / "windsurf-next" / "hooks.json"
+        config = json.loads(hooks_path.read_text(encoding="utf-8"))
+        for event in HOOK_EVENTS:
+            assert len(config["hooks"][event]) == 1
+
+    def test_preserves_existing_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("windsurf_teacher.installer._build_hook_command", lambda: "/usr/bin/python capture.py")
+
+        hooks_path = tmp_path / "windsurf-next" / "hooks.json"
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        hooks_path.write_text(
+            json.dumps({"hooks": {"post_cascade_response": [{"command": "other-tool", "show_output": True}]}}), encoding="utf-8"
+        )
+
+        _install_hooks()
+        config = json.loads(hooks_path.read_text(encoding="utf-8"))
+        assert len(config["hooks"]["post_cascade_response"]) == 2
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestInstallMcpServer:
+    def test_registers_server(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("windsurf_teacher.installer.PROJECT_DIR", tmp_path / "project")
+
+        _install_mcp_server()
+        mcp_path = tmp_path / "windsurf-next" / "mcp_config.json"
+        config = json.loads(mcp_path.read_text(encoding="utf-8"))
+        assert MCP_SERVER_NAME in config["mcpServers"]
+        assert config["mcpServers"][MCP_SERVER_NAME]["command"] == "uv"
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestUninstallSkill:
+    def test_removes_skill_dir(self, tmp_path):
+        skill_dir = tmp_path / "windsurf-next" / "skills" / "learn-mode"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("test", encoding="utf-8")
+
+        _uninstall_skill()
+        assert not skill_dir.exists()
+
+    def test_no_error_if_missing(self, capsys):
+        _uninstall_skill()
+        assert "not installed" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestUninstallHooks:
+    def test_removes_our_hooks(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("windsurf_teacher.installer._build_hook_command", lambda: "/usr/bin/python capture.py")
+
+        hooks_path = tmp_path / "windsurf-next" / "hooks.json"
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        hooks_path.write_text(
+            json.dumps({
+                "hooks": {
+                    "post_cascade_response": [
+                        {"command": "/usr/bin/python capture_session.py"},
+                        {"command": "other-tool"},
+                    ],
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        _uninstall_hooks()
+        config = json.loads(hooks_path.read_text(encoding="utf-8"))
+        assert len(config["hooks"]["post_cascade_response"]) == 1
+        assert config["hooks"]["post_cascade_response"][0]["command"] == "other-tool"
+
+    def test_no_error_if_no_hooks_json(self, capsys):
+        _uninstall_hooks()
+        assert "No hooks.json" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestUninstallMcpServer:
+    def test_removes_server_entry(self, tmp_path):
+        mcp_path = tmp_path / "windsurf-next" / "mcp_config.json"
+        mcp_path.parent.mkdir(parents=True, exist_ok=True)
+        mcp_path.write_text(
+            json.dumps({"mcpServers": {MCP_SERVER_NAME: {"command": "uv"}, "other": {"command": "node"}}}), encoding="utf-8"
+        )
+
+        _uninstall_mcp_server()
+        config = json.loads(mcp_path.read_text(encoding="utf-8"))
+        assert MCP_SERVER_NAME not in config["mcpServers"]
+        assert "other" in config["mcpServers"]
+
+    def test_no_error_if_no_config(self, capsys):
+        _uninstall_mcp_server()
+        assert "No mcp_config.json" in capsys.readouterr().out
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestRunInstall:
+    def test_full_install(self, tmp_path, monkeypatch, capsys):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "SKILL.md").write_text("# skill", encoding="utf-8")
+        monkeypatch.setattr("windsurf_teacher.installer.PROJECT_DIR", project_dir)
+        monkeypatch.setattr("windsurf_teacher.installer._build_hook_command", lambda: "python capture.py")
+
+        run_install()
+        out = capsys.readouterr().out
+        assert "Installing" in out
+        assert "Done" in out
+        assert (tmp_path / "db").exists()
+
+
+@pytest.mark.usefixtures("_patch_paths")
+class TestRunUninstall:
+    def test_full_uninstall_keep_db(self, tmp_path, monkeypatch, capsys):
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        run_uninstall()
+        out = capsys.readouterr().out
+        assert "Uninstalling" in out
+        assert "Kept" in out
+        assert db_dir.exists()
+
+    def test_full_uninstall_delete_db(self, tmp_path, monkeypatch, capsys):
+        db_dir = tmp_path / "db"
+        db_dir.mkdir()
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+
+        run_uninstall()
+        out = capsys.readouterr().out
+        assert "Removed" in out
+        assert not db_dir.exists()
+
+    def test_uninstall_no_db(self, capsys):
+        run_uninstall()
+        out = capsys.readouterr().out
+        assert "Done" in out

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,175 @@
+"""Tests for windsurf_teacher.mcp_server module."""
+
+from __future__ import annotations
+
+import pytest
+
+from windsurf_teacher.db import get_db
+from windsurf_teacher.mcp_server import (
+    export_review_markdown,
+    get_learning_gaps,
+    get_session_summary,
+    log_concept,
+    log_gotcha,
+    log_pattern,
+    query_concepts,
+)
+
+
+@pytest.fixture
+def _patch_db(tmp_path, monkeypatch):
+    """Patch get_db in mcp_server to use a temp database."""
+    db_path = tmp_path / "test.db"
+    monkeypatch.setattr("windsurf_teacher.mcp_server.get_db", lambda: get_db(db_path))
+
+
+@pytest.fixture
+def db_conn(tmp_path, _patch_db):
+    """Return a connection to the same patched database."""
+    db_path = tmp_path / "test.db"
+    conn = get_db(db_path)
+    yield conn
+    conn.close()
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestLogConcept:
+    def test_logs_concept(self):
+        result = log_concept(name="walrus operator", explanation=":= assigns and returns")
+        assert "walrus operator" in result
+        assert "logged" in result
+
+    def test_logs_with_tags(self):
+        result = log_concept(name="fstring", explanation="formatted strings", tags=["python", "syntax"])
+        assert "fstring" in result
+
+    def test_concept_stored_in_db(self, db_conn):
+        log_concept(name="generator", explanation="yields values", code_example="yield x", tags=["python"])
+        row = db_conn.execute("SELECT * FROM concepts WHERE name = 'generator'").fetchone()
+        assert row is not None
+        assert row["source"] == "mcp"
+        assert row["code_example"] == "yield x"
+        assert "python" in row["tags"]
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestLogPattern:
+    def test_logs_new_pattern(self):
+        result = log_pattern(name="factory", description="creates objects")
+        assert "factory" in result
+        assert "logged" in result
+
+    def test_increments_existing_pattern(self):
+        log_pattern(name="singleton", description="one instance")
+        result = log_pattern(name="singleton", description="one instance only")
+        assert "seen 2 times" in result
+
+    def test_pattern_stored_in_db(self, db_conn):
+        log_pattern(name="observer", description="event subscription", tags=["design"])
+        row = db_conn.execute("SELECT * FROM patterns WHERE name = 'observer'").fetchone()
+        assert row is not None
+        assert row["times_seen"] == 1
+        assert "design" in row["tags"]
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestLogGotcha:
+    def test_logs_gotcha(self):
+        result = log_gotcha(description="mutable default args")
+        assert "logged" in result
+        assert "warning" in result
+
+    def test_logs_with_severity(self):
+        result = log_gotcha(description="sql injection", severity="danger")
+        assert "danger" in result
+
+    def test_links_to_concept(self, db_conn):
+        log_concept(name="dict.get", explanation="returns None by default")
+        log_gotcha(description="forgot default", concept_name="dict.get")
+        gotcha = db_conn.execute("SELECT * FROM gotchas").fetchone()
+        assert gotcha["concept_id"] is not None
+
+    def test_unlinked_gotcha(self, db_conn):
+        log_gotcha(description="standalone gotcha", concept_name="nonexistent")
+        gotcha = db_conn.execute("SELECT * FROM gotchas").fetchone()
+        assert gotcha["concept_id"] is None
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestQueryConcepts:
+    def test_returns_recent_when_no_filters(self):
+        log_concept(name="abc", explanation="abstract base class")
+        result = query_concepts()
+        assert "abc" in result
+
+    def test_search_by_text(self):
+        log_concept(name="decorator", explanation="wraps functions")
+        result = query_concepts(search="decorator")
+        assert "decorator" in result
+
+    def test_search_by_tags(self):
+        log_concept(name="asyncio", explanation="async framework", tags=["concurrency"])
+        result = query_concepts(tags="concurrency")
+        assert "asyncio" in result
+
+    def test_no_results(self):
+        result = query_concepts(search="zzzznonexistent")
+        assert "No concepts found" in result
+
+    def test_limit(self):
+        for i in range(5):
+            log_concept(name=f"concept-{i}", explanation=f"explanation {i}")
+        result = query_concepts(limit=2)
+        assert result.count("- **") == 2
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestGetLearningGaps:
+    def test_returns_unreviewed_concepts(self):
+        log_concept(name="pathlib", explanation="object-oriented paths")
+        result = get_learning_gaps()
+        assert "pathlib" in result
+        assert "never reviewed" in result
+
+    def test_no_gaps(self):
+        result = get_learning_gaps()
+        assert "up to date" in result
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestExportReviewMarkdown:
+    def test_export_with_concepts(self):
+        log_concept(name="context manager", explanation="with statement", tags=["python"])
+        log_pattern(name="factory", description="object creation")
+        log_gotcha(description="mutable defaults")
+        result = export_review_markdown(days=1)
+        assert "# Learning Review" in result
+        assert "context manager" in result
+        assert "factory" in result
+        assert "mutable defaults" in result
+
+    def test_export_empty(self):
+        result = export_review_markdown(days=0)
+        assert "No learnings found" in result
+
+
+@pytest.mark.usefixtures("_patch_db")
+class TestGetSessionSummary:
+    def test_no_sessions(self):
+        result = get_session_summary()
+        assert "No sessions found" in result
+
+    def test_summary_of_session(self, db_conn):
+        db_conn.execute("INSERT INTO sessions (id, started_at, project_path) VALUES ('s1', '2025-01-01T00:00:00', '/project')")
+        db_conn.execute("INSERT INTO responses (session_id, timestamp, response_text) VALUES ('s1', '2025-01-01T00:00:00', 'hi')")
+        db_conn.commit()
+        result = get_session_summary(session_id="s1")
+        assert "s1" in result
+        assert "1 responses" in result
+
+    def test_most_recent_session(self, db_conn):
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('old', '2024-01-01T00:00:00')")
+        db_conn.execute("INSERT INTO sessions (id, started_at) VALUES ('new', '2025-06-01T00:00:00')")
+        db_conn.commit()
+        result = get_session_summary()
+        assert "new" in result


### PR DESCRIPTION
## Summary

Add comprehensive README, tests for all untested modules, and bring coverage above the 90% threshold.

## What changed

- **`README.md`** — rewrote from template to full project documentation: how it works, requirements, installation, usage (Windsurf + CLI), uninstalling, development commands, and architecture tree
- **`tests/test_mcp_server.py`** — 22 tests covering all 7 MCP tools (log/query/export/gaps/summary)
- **`tests/test_cli.py`** — 9 tests covering stats, search, review, export (stdout + file), and main entry point
- **`tests/test_installer.py`** — 19 tests covering JSON helpers, skill/hooks/MCP install+uninstall, idempotency, existing-config preservation, full install/uninstall flows, and DB deletion prompt
- **`pyproject.toml`** — added `[[tool.ty.overrides]]` to suppress `call-non-callable` false positives in `test_mcp_server.py` (FastMCP v3 rc2 type stubs incorrectly expose `FunctionTool` instead of the original function)

## Coverage

| Module | Before | After |
|--------|--------|-------|
| `db.py` | 100% | 100% |
| `hooks/capture_session.py` | 92% | 92% |
| `mcp_server.py` | 0% | 93% |
| `cli.py` | 0% | 91% |
| `installer.py` | 0% | 89% |
| **Total** | **19.5%** | **91.8%** |