### PR TITLE
feat: add mark_reviewed tool, dedup CLI export, db fast-path, auto-install workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,14 @@ jobs:
 
     needs:
     - quality
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - blacksmith-4vcpu-ubuntu-2404
+        - macos-latest
+        - windows-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout
@@ -128,6 +135,7 @@ jobs:
       run: uv run poe test-cov
 
     - name: Upload coverage to Codecov
+      if: matrix.os == 'blacksmith-4vcpu-ubuntu-2404'
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This installs:
 1. The `learn-mode` skill into `~/.codeium/windsurf-next/skills/learn-mode/`
 2. Hook entries into `~/.codeium/windsurf-next/hooks.json` (merged with existing hooks)
 3. The MCP server into `~/.codeium/windsurf-next/mcp_config.json`
-4. The learning database directory at `~/.windsurf-teacher/`
+4. The `learn-review.md` workflow into `~/.codeium/windsurf-next/global_workflows/`
+5. The learning database directory at `~/.windsurf-teacher/`
 
 Restart Windsurf after installing.
 
@@ -80,7 +81,7 @@ windsurf-teacher serve
 
 ### Global workflow
 
-Copy `learn-review.md` to `~/.codeium/windsurf-next/global_workflows/` to add a `/learn-review` command that quizzes you on recent concepts.
+The installer automatically copies `learn-review.md` to `~/.codeium/windsurf-next/global_workflows/`. Type `/learn-review` in Cascade to start a spaced-repetition quiz on recent concepts.
 
 ## Uninstalling
 

--- a/learn-review.md
+++ b/learn-review.md
@@ -7,4 +7,4 @@ auto_execution_mode: 1
 2. Pick 3-5 concepts that are due for review
 3. For each concept, briefly explain it and ask me a question that tests understanding (not memory)
 4. After I answer, confirm whether I got it right and add any nuance I missed
-5. At the end, use `log_concept` to update the review_count for concepts I got right
+5. At the end, use `mark_reviewed` to update the review_count for concepts I got right

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ ignore = [
     "DTZ005",     # Naive datetime in tests is fine
     "PLR0904",    # Test classes naturally have many test methods
 ]
+"src/windsurf_teacher/installer.py" = ["S404"]  # subprocess.list2cmdline is a pure string formatter, not a process spawner
 "install.py" = ["T201"]   # CLI script needs print()
 "uninstall.py" = ["T201"] # CLI script needs print()
 
@@ -192,7 +193,7 @@ python-version = "3.14"
 python = ".venv"
 
 [[tool.ty.overrides]]
-include = ["tests/test_mcp_server.py"]
+include = ["tests/test_mcp_server.py", "src/windsurf_teacher/cli.py"]
 
 [tool.ty.overrides.rules]
 call-non-callable = "ignore"  # FastMCP v3 rc2 type stubs incorrectly expose FunctionTool

--- a/src/windsurf_teacher/db.py
+++ b/src/windsurf_teacher/db.py
@@ -117,6 +117,9 @@ CREATE INDEX IF NOT EXISTS idx_gotchas_concept ON gotchas(concept_id);
 """
 
 
+_INITIALIZED: set[Path] = set()
+
+
 def _init_db(conn: sqlite3.Connection) -> None:
     """Create tables, FTS5 indexes, and set schema version."""
     conn.executescript(_TABLES_SQL)
@@ -146,5 +149,7 @@ def get_db(db_path: Path | None = None) -> sqlite3.Connection:
     conn.execute("PRAGMA foreign_keys=ON")
     conn.row_factory = sqlite3.Row
 
-    _init_db(conn)
+    if path not in _INITIALIZED:
+        _init_db(conn)
+        _INITIALIZED.add(path)
     return conn

--- a/src/windsurf_teacher/hooks/capture_session.py
+++ b/src/windsurf_teacher/hooks/capture_session.py
@@ -12,6 +12,7 @@ import logging
 import re
 import sys
 from datetime import UTC, datetime
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -72,7 +73,12 @@ def _handle_post_write_code(conn, data: dict) -> None:
         return
 
     session_id = data.get("trajectory_id") or f"session-{_now_iso()}"
-    project_path = str(file_path).rsplit("/src/", maxsplit=1)[0] if "/src/" in str(file_path) else None
+    fp = PurePath(file_path)
+    try:
+        src_idx = fp.parts.index("src")
+        project_path = str(PurePath(*fp.parts[:src_idx]))
+    except ValueError:
+        project_path = None
     _ensure_session(conn, session_id, project_path)
 
     for edit in edits:

--- a/src/windsurf_teacher/mcp_server.py
+++ b/src/windsurf_teacher/mcp_server.py
@@ -269,3 +269,24 @@ def get_session_summary(session_id: str = "") -> str:
         return "\n".join(lines)
     finally:
         conn.close()
+
+
+@mcp.tool
+def mark_reviewed(concept_id: int) -> str:
+    """Mark a concept as reviewed, incrementing its review count.
+
+    Call this after a user correctly answers a review question.
+    """
+    conn = get_db()
+    try:
+        row = conn.execute("SELECT id, name FROM concepts WHERE id = ?", (concept_id,)).fetchone()
+        if not row:
+            return f"Concept {concept_id} not found."
+        conn.execute(
+            "UPDATE concepts SET reviewed_at = ?, review_count = review_count + 1 WHERE id = ?",
+            (_now_iso(), concept_id),
+        )
+        conn.commit()
+        return f"✓ Marked **{row['name']}** as reviewed (concept {concept_id})."
+    finally:
+        conn.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ def _patch_db(tmp_path, monkeypatch):
     """Patch get_db in cli to use a temp database."""
     db_path = tmp_path / "test.db"
     monkeypatch.setattr("windsurf_teacher.cli.get_db", lambda: get_db(db_path))
+    monkeypatch.setattr("windsurf_teacher.mcp_server.get_db", lambda: get_db(db_path))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Add the `mark_reviewed` MCP tool, deduplicate CLI export logic, add a DB init fast-path, auto-install the learn-review workflow, and harden cross-platform support.

## What changed

- **`src/windsurf_teacher/mcp_server.py`** — new `mark_reviewed` tool: increments `review_count` and sets `reviewed_at` for a concept by ID
- **`src/windsurf_teacher/cli.py`** — `export` command now delegates to `export_review_markdown()` from `mcp_server`, removing ~25 lines of duplicated SQL/formatting
- **`src/windsurf_teacher/db.py`** — added `_INITIALIZED` set so `_init_db()` is skipped on repeated `get_db()` calls to the same path (fast-path)
- **`src/windsurf_teacher/installer.py`** — installs/uninstalls `learn-review.md` into `~/.codeium/windsurf-next/global_workflows/`; cross-platform python path resolution (Windows `Scripts/python.exe`); Windows-safe hook command via `subprocess.list2cmdline`
- **`src/windsurf_teacher/hooks/capture_session.py`** — replaced fragile `str.rsplit("/src/")` with `PurePath.parts.index("src")` for robust project path extraction
- **Tests** — updated `test_cli.py`, `test_installer.py`, `test_mcp_server.py` for the new tool and refactored export
- **`pyproject.toml`** — extended `ty` overrides to cover `cli.py`
- **`README.md`**, **`learn-review.md`**, **`.github/workflows/ci.yml`** — minor updates