### PR TITLE
chore: fix lychee link errors and update copier template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier.
-_commit: 0.28.4
+_commit: 0.28.5
 _src_path: gh:detailobsessed/copier-uv-bleeding
 author_email: ismart@gmail.com
 author_fullname: Ismar Iljazovic

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -6,7 +6,7 @@ labels: enhancement
 assignees: [ichoosetoaccept]
 ---
 
-### Is your feature request related to a problem? Please describe.
+### Is your feature request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]. -->
 
 ### Describe the solution you'd like

--- a/.github/ISSUE_TEMPLATE/4-change.md
+++ b/.github/ISSUE_TEMPLATE/4-change.md
@@ -6,7 +6,7 @@ labels: enhancement
 assignees: [ichoosetoaccept]
 ---
 
-### Is your change request related to a problem? Please describe.
+### Is your change request related to a problem? Please describe
 <!-- A clear and concise description of what the problem is. -->
 
 ### Describe the solution you'd like

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     outputs:
       src: ${{ steps.filter.outputs.src }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
       id: filter
       with:
         filters: |
@@ -51,9 +51,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Check links
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
       with:
         fail: true
         args: --no-progress .
@@ -65,13 +65,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         python-version: "3.14"
         enable-cache: true
@@ -90,7 +90,7 @@ jobs:
       run: uv run poe check
 
     - name: Store objects inventory for tests
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
       with:
         name: objects.inv
         path: site/objects.inv
@@ -110,13 +110,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv and Python
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         python-version: "3.14"
         enable-cache: true
@@ -126,7 +126,7 @@ jobs:
       run: uv run poe setup
 
     - name: Download objects inventory
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
       with:
         name: objects.inv
         path: site/
@@ -136,7 +136,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'blacksmith-4vcpu-ubuntu-2404'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false

--- a/.github/workflows/copier-update.yml
+++ b/.github/workflows/copier-update.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: actions-ext/copier-update@v0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         fetch-depth: 0
         fetch-tags: true
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
       with:
         python-version: "3.14"
         enable-cache: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -13,6 +13,12 @@ exclude = [
     '^mailto:',
     # Localhost URLs (e.g. docs preview in CONTRIBUTING.md)
     '^http://localhost',
+    # GitHub Pages — not deployed yet
+    '^https://detailobsessed\.github\.io/windsurf-teacher',
+    # GitHub Discussions — not enabled yet
+    '^https://github\.com/detailobsessed/windsurf-teacher/discussions',
+    # Workflow badge SVGs — 404 until first workflow run completes
+    '^https://github\.com/detailobsessed/windsurf-teacher/actions/workflows/.+/badge\.svg',
 ]
 
 # Exclude local/private addresses

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at ismart@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <ismart@gmail.com>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # windsurf-teacher
 
-[![ci](https://github.com/detailobsessed/windsurf-teacher/workflows/ci/badge.svg)](https://github.com/detailobsessed/windsurf-teacher/actions?query=workflow%3Aci)
-[![release](https://github.com/detailobsessed/windsurf-teacher/workflows/release/badge.svg)](https://github.com/detailobsessed/windsurf-teacher/actions?query=workflow%3Arelease)
+[![ci](https://github.com/detailobsessed/windsurf-teacher/actions/workflows/ci.yml/badge.svg)](https://github.com/detailobsessed/windsurf-teacher/actions/workflows/ci.yml)
+[![release](https://github.com/detailobsessed/windsurf-teacher/actions/workflows/release.yml/badge.svg)](https://github.com/detailobsessed/windsurf-teacher/actions/workflows/release.yml)
 [![documentation](https://img.shields.io/badge/docs-mkdocs-708FCC.svg?style=flat)](https://detailobsessed.github.io/windsurf-teacher/)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 [![codecov](https://codecov.io/gh/detailobsessed/windsurf-teacher/branch/main/graph/badge.svg)](https://codecov.io/gh/detailobsessed/windsurf-teacher)
@@ -12,7 +12,7 @@
 
 ```text
 coding sessions → hooks capture responses/diffs → SQLite stores structured learnings
-                                                 → export to markdown → NotebookLM flashcards
+                                                 → export to markdown → NotebookLM flashcards (if you want)
 ```
 
 - **Skill** (`@learn-mode`) — changes Cascade's behavior to explain before writing, annotate code with `# LEARN:` comments, and summarize patterns
@@ -90,6 +90,22 @@ uv run windsurf-teacher uninstall
 ```
 
 This removes the skill, hooks, and MCP server entries (leaving other hooks/servers intact). You'll be asked whether to delete the learning database.
+
+## Database
+
+All learning data lives in a single SQLite file at `~/.windsurf-teacher/learnings.db`. Everything is automatic:
+
+- **Created on first use** — the directory and database file are created the first time a hook fires or an MCP tool is called. No manual setup required.
+- **Schema auto-initialized** — 7 tables (sessions, responses, code_changes, commands, concepts, patterns, gotchas), FTS5 full-text search on concepts, and indexes are created via `CREATE TABLE IF NOT EXISTS` on first connection.
+- **WAL mode** — the database uses `PRAGMA journal_mode=WAL` so hooks can write while the CLI reads concurrently.
+- **No migrations (yet)** — the schema is versioned (`schema_version` table) but there are no migration steps since this is v1. Future schema changes will add migration logic in `db.py`.
+- **Deleted on uninstall** — `windsurf-teacher uninstall` prompts whether to delete `~/.windsurf-teacher/` (including the database). If you decline, your data is preserved for a future reinstall.
+- **Backup** — the DB is a single file; copy `~/.windsurf-teacher/learnings.db` to back it up.
+
+## Branch protection
+
+The CI workflow includes a `ci-pass` gate job that aggregates the status of all CI jobs.
+Add a [branch protection rule](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule) for `main` requiring the **`ci-pass`** status check to pass before merging.
 
 ## Development
 

--- a/README_TEMPLATE.md
+++ b/README_TEMPLATE.md
@@ -5,7 +5,7 @@ and kept up to date on every `copier update`. Your project README lives in `READ
 
 ## Badges
 
-Copy these into your `README.md` to show project status on GitHub:
+Copy these into your `README.md` to show project status:
 
 ```markdown
 [![ci](https://github.com/detailobsessed/windsurf-teacher/workflows/ci/badge.svg)](https://github.com/detailobsessed/windsurf-teacher/actions?query=workflow%3Aci)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ source = ["src/"]
 
 [tool.coverage.report]
 precision = 2
-omit = ["src/*/__init__.py", "tests/__init__.py"]
+omit = ["src/*/__init__.py"]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING", "if __name__ == .__main__.:"]
 
 [tool.coverage.json]

--- a/uv.lock
+++ b/uv.lock
@@ -312,16 +312,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/f1/2a/8c3ac3d8bc94e6de8
 
 [[package]]
 name = "cyclopts"
-version = "5.0.0a4"
+version = "4.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "docstring-parser" },
     { name = "rich" },
+    { name = "rich-rst" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/67/b3/94794719d453b40186ae27e6f322e2f960bec2582bd0a7b96c1523982fba/cyclopts-5.0.0a4.tar.gz", hash = "sha256:41fe38798b3110f0752ef77b5da34a11e6affcd410c2623428fffa461e34c887", size = 167009, upload-time = "2026-01-26T15:32:37.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/16/06e35c217334930ff7c476ce1c8e74ed786fa3ef6742e59a1458e2412290/cyclopts-4.5.3.tar.gz", hash = "sha256:35fa70971204c450d9668646a6ca372eb5fa3070fbe8dd51c5b4b31e65198f2d", size = 162437, upload-time = "2026-02-16T15:07:11.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/41/f137a110546ba61fcdfecd522b2f3ba31719c90abe930fc18f36d12cd5fb/cyclopts-5.0.0a4-py3-none-any.whl", hash = "sha256:9eaa2d747c9b516d17580cdad2a1c33eed1bb90c7ec5ca18086364d85ad65bb7", size = 205057, upload-time = "2026-01-26T15:32:35.959Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/1f/d8bce383a90d8a6a11033327777afa4d4d611ec11869284adb6f48152906/cyclopts-4.5.3-py3-none-any.whl", hash = "sha256:50af3085bb15d4a6f2582dd383dad5e4ba6a0d4d4c64ee63326d881a752a6919", size = 200231, upload-time = "2026-02-16T15:07:13.045Z" },
 ]
 
 [[package]]
@@ -361,6 +362,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
 
 [[package]]
@@ -672,16 +682,17 @@ wheels = [
 
 [[package]]
 name = "jsonschema-path"
-version = "0.4.0b6"
+version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pathable" },
     { name = "pyyaml" },
     { name = "referencing" },
+    { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/07/ac/48107dc0a11af9e66c72deeda01d13237aba2ec65162472d01c7223a4398/jsonschema_path-0.4.0b6.tar.gz", hash = "sha256:e1b88f65545604d8e81221ba88148d85aafb99bd916bad5838a5614f914bd886", size = 13286, upload-time = "2026-02-15T23:20:27.006Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/45/41ebc679c2a4fced6a722f624c18d658dee42612b83ea24c1caf7c0eb3a8/jsonschema_path-0.3.4.tar.gz", hash = "sha256:8365356039f16cc65fddffafda5f58766e34bebab7d6d105616ab52bc4297001", size = 11159, upload-time = "2025-01-24T14:33:16.547Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/d2/9333d35c54396482faa972edbdd4f2f518941f28da87eb5097b02258ba78/jsonschema_path-0.4.0b6-py3-none-any.whl", hash = "sha256:6b988750daa9c078f41c828c4f780399166012facce60e6245c2620d8b6fbf18", size = 16460, upload-time = "2026-02-15T23:20:25.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/58/3485da8cb93d2f393bce453adeef16896751f14ba3e2024bc21dc9597646/jsonschema_path-0.3.4-py3-none-any.whl", hash = "sha256:f502191fdc2b22050f9a81c9237be9d27145b9001c55842bece5e94e382e52f8", size = 14810, upload-time = "2025-01-24T14:33:14.652Z" },
 ]
 
 [[package]]
@@ -1120,11 +1131,11 @@ wheels = [
 
 [[package]]
 name = "pathable"
-version = "0.5.0b6"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6e/bb/35058eae372ecf815b265504c9dbef4b2afcaa765fe59b9cafc4dc090814/pathable-0.5.0b6.tar.gz", hash = "sha256:a36763b534a213894ddbca01db5b869aca52779e89a193078304fb3706b94404", size = 16520, upload-time = "2026-02-15T21:32:55.142Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/93/8f2c2075b180c12c1e9f6a09d1a985bc2036906b13dff1d8917e395f2048/pathable-0.4.4.tar.gz", hash = "sha256:6905a3cd17804edfac7875b5f6c9142a218c7caef78693c2dbbbfbac186d88b2", size = 8124, upload-time = "2025-01-10T18:43:13.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/f5/678521a801273320ebdfb2b62f4dd22d0246ef3ae79baa2064f0b866d462/pathable-0.5.0b6-py3-none-any.whl", hash = "sha256:c66bafb0e93b790098e580a1c89e042a24148d6541098f18d24ae1fc77e1b335", size = 16733, upload-time = "2026-02-15T21:32:53.975Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/eb/b6260b31b1a96386c0a880edebe26f89669098acea8e0318bff6adb378fd/pathable-0.4.4-py3-none-any.whl", hash = "sha256:5ae9e94793b6ef5a4cbe0a7ce9dbbefc1eec38df253763fd0aeeacf2762dbbc2", size = 9592, upload-time = "2025-01-10T18:43:11.88Z" },
 ]
 
 [[package]]
@@ -1591,6 +1602,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
+]
+
+[[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Fix lychee link-checker errors on URLs that legitimately 404 (GitHub Pages, Discussions, workflow badges) and update the copier template with pinned action versions and minor fixes.

## What changed

- **`.lychee.toml`** — added exclusions for GitHub Pages docs site, Discussions link, and workflow badge SVGs (all 404 until first deploy/enable/run)
- **`.github/workflows/ci.yml`** — pinned `actions/checkout` and `astral-sh/setup-uv` to commit hashes with version comments
- **`.github/workflows/release.yml`** — same action pinning
- **`.github/workflows/copier-update.yml`** — same action pinning
- **`README.md`** — fixed badge URLs to use `/actions/workflows/<name>.yml/badge.svg` format; added branch-protection section documenting the `ci-pass` gate job; minor wording tweak
- **`README_TEMPLATE.md`** — minor wording fix
- **`CODE_OF_CONDUCT.md`** — wrapped bare email in angle brackets for proper markdown linking
- **`pyproject.toml`** — removed `tests/__init__.py` from coverage omit list
- **`uv.lock`** — dependency resolution updates (cyclopts, jsonschema-path version changes; added docutils, rich-rst)
- **`.copier-answers.yml`**, **`.github/ISSUE_TEMPLATE/`** — copier template sync